### PR TITLE
Upgrade Docker Dependencies

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ networks:
 
 services:
   caddy:
-    image: caddy:2.11.2
+    image: caddy:latest
     restart: unless-stopped
     container_name: caddy
     hostname: caddy
@@ -30,7 +30,7 @@ services:
   tailscale:
     env_file: .env
     container_name: tailscaled
-    image: tailscale/tailscale:v1.96.5
+    image: tailscale/tailscale:latest
     network_mode: host
     cap_add:
       - NET_ADMIN
@@ -43,19 +43,19 @@ services:
       - TS_STATE_DIR=/var/lib/tailscale
 
   web1:
-    image: httpd:2.4.66
+    image: httpd:latest
     container_name: web1
     networks:
       - proxy-network
 
   web2:
-    image: httpd:2.4.66
+    image: httpd:latest
     container_name: web2
     networks:
       - proxy-network
 
   web3:
-    image: httpd:2.4.66
+    image: httpd:latest
     container_name: web3
     networks:
       - proxy-network

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ networks:
 
 services:
   caddy:
-    image: caddy:latest
+    image: caddy:2.11.2
     restart: unless-stopped
     container_name: caddy
     hostname: caddy
@@ -30,7 +30,7 @@ services:
   tailscale:
     env_file: .env
     container_name: tailscaled
-    image: tailscale/tailscale
+    image: tailscale/tailscale:v1.96.5
     network_mode: host
     cap_add:
       - NET_ADMIN
@@ -43,19 +43,19 @@ services:
       - TS_STATE_DIR=/var/lib/tailscale
 
   web1:
-    image: httpd:latest
+    image: httpd:2.4.66
     container_name: web1
     networks:
       - proxy-network
 
   web2:
-    image: httpd:latest
+    image: httpd:2.4.66
     container_name: web2
     networks:
       - proxy-network
 
   web3:
-    image: httpd:latest
+    image: httpd:2.4.66
     container_name: web3
     networks:
       - proxy-network


### PR DESCRIPTION
Upgraded `caddy`, `tailscale/tailscale`, and `httpd` image tags to their latest stable versions in `docker-compose.yaml`. Tested the setup locally to ensure everything builds and starts correctly.

---
*PR created automatically by Jules for task [10723922647924738676](https://jules.google.com/task/10723922647924738676) started by @nsudhanva*